### PR TITLE
Fix for nonce rpc

### DIFF
--- a/frame/system/src/extensions/check_nonce.rs
+++ b/frame/system/src/extensions/check_nonce.rs
@@ -35,7 +35,7 @@ use sp_std::vec;
 /// Note that this does not set any priority by default. Make sure that AT LEAST one of the signed
 /// extension sets some kind of priority upon validating transactions.
 #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-pub struct CheckNonce<T: Trait>(#[codec(compact)] T::Index);
+pub struct CheckNonce<T: Trait>(#[codec(compact)] pub T::Index);
 
 impl<T: Trait> CheckNonce<T> {
 	/// utility constructor. Used only in client/factory code.


### PR DESCRIPTION
Minor change to frame_system::CheckNonce
Can be merged independently. 